### PR TITLE
salt for installing obs server on master

### DIFF
--- a/llvm-obs/obs-conf/obs-api_database.yml
+++ b/llvm-obs/obs-conf/obs-api_database.yml
@@ -1,0 +1,16 @@
+# MySQL (default setup).  Versions 4.1 and 5.0 are recommended.
+#
+# Get the fast C bindings:
+#   gem install mysql
+#   (on OS X: gem install mysql -- --include=/usr/local/lib)
+# And be sure to use new-style password hashing:
+#   http://dev.mysql.com/doc/refman/5.0/en/old-client.html
+
+production:
+  adapter: mysql2
+  database: api_production
+  username: obs
+  password: topsecretpasskey
+  encoding: utf8
+  timeout: 15
+  pool: 30

--- a/llvm-obs/obs-conf/obs-api_database.yml
+++ b/llvm-obs/obs-conf/obs-api_database.yml
@@ -8,9 +8,9 @@
 
 production:
   adapter: mysql2
-  database: api_production
-  username: obs
-  password: topsecretpasskey
+  database: {{salt['pillar.get']('obs-database:lookup:obs-api-database') }} 
+  username: {{salt['pillar.get']('obs-database:lookup:obs-user') }}
+  password: {{salt['pillar.get']('obs-database:lookup:obs-api-database-password') }}
   encoding: utf8
   timeout: 15
   pool: 30

--- a/llvm-obs/obs-scripts/generate_ssl.sh
+++ b/llvm-obs/obs-scripts/generate_ssl.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+mkdir /srv/obs/certs
+openssl genrsa -out /srv/obs/certs/server.key 1024
+openssl req -new -key /srv/obs/certs/server.key \
+	         -out /srv/obs/certs/server.csr
+openssl x509 -req -days 365 -in /srv/obs/certs/server.csr \
+	     -signkey /srv/obs/certs/server.key \
+	     -out /srv/obs/certs/server.crt
+
+cat /srv/obs/certs/server.key /srv/obs/certs/server.crt \
+	      > /srv/obs/certs/server.pem
+cp /srv/obs/certs/server.pem /etc/ssl/certs/
+c_rehash /etc/ssl/certs/

--- a/llvm-obs/obs-scripts/generate_ssl.sh
+++ b/llvm-obs/obs-scripts/generate_ssl.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-mkdir /srv/obs/certs
+mkdir -p /srv/obs/certs
 openssl genrsa -out /srv/obs/certs/server.key 1024
 openssl req -new -key /srv/obs/certs/server.key \
 	         -out /srv/obs/certs/server.csr

--- a/llvm-obs/obs-scripts/grant_permissions.sh
+++ b/llvm-obs/obs-scripts/grant_permissions.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 mysql -u root -p{{salt['pillar.get']('obs-database:lookup:root-password')}} <<EOF
 set sql_mode = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION';
-GRANT all privileges ON api_production.* TO 'obs'@'%', 'obs'@'localhost';
+GRANT all privileges ON {{salt['pillar.get']('obs-database:lookup:obs-api-database')}}.* TO '{{salt['pillar.get']('obs-database:lookup:obs-user')}}'@'%', '{{salt['pillar.get']('obs-database:lookup:obs-user')}}'@'localhost';
 FLUSH PRIVILEGES;
 EOF

--- a/llvm-obs/obs-scripts/grant_permissions.sh
+++ b/llvm-obs/obs-scripts/grant_permissions.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-mysql -u root -pTOPSECRET <<EOF
+mysql -u root -p{{salt['pillar.get']('obs-database:lookup:root-password')}} <<EOF
 set sql_mode = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION';
 GRANT all privileges ON api_production.* TO 'obs'@'%', 'obs'@'localhost';
 FLUSH PRIVILEGES;

--- a/llvm-obs/obs-scripts/grant_permissions.sh
+++ b/llvm-obs/obs-scripts/grant_permissions.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+mysql -u root -pTOPSECRET <<EOF
+set sql_mode = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION';
+GRANT all privileges ON api_production.* TO 'obs'@'%', 'obs'@'localhost';
+FLUSH PRIVILEGES;
+EOF

--- a/mysql_init.sls
+++ b/mysql_init.sls
@@ -48,7 +48,7 @@ create obs for api user@localhost:
 create obs for api user@%:
   mysql_user.present:
     - name: {{salt['pillar.get']('obs-database:lookup:obs-user') }}
-    - host: \%
+    - host: '%'
     - password: {{salt['pillar.get']('obs-database:lookup:obs-api-database-password') }}
 
 grant permission:

--- a/mysql_init.sls
+++ b/mysql_init.sls
@@ -55,6 +55,7 @@ grant permission:
   cmd.script:
     - name: grant_permissions.sh
     - source: salt://llvm-obs/obs-scripts/grant_permissions.sh
+    - template: jinja
 
 mysql_restart:
   module.wait:

--- a/mysql_init.sls
+++ b/mysql_init.sls
@@ -1,0 +1,95 @@
+install_mysql:
+  pkg.installed:
+    - pkgs:
+      - mysql-server
+      - python-mysqldb 
+
+reload-mysql:
+  service.running:
+    - name: mysql
+    - enable: True
+    - reload: True
+
+root_user:
+  mysql_user.present:
+    - name: 'root'
+    - password: 'TOPSECRET'
+
+mysql remove anonymous users:
+  mysql_user.absent:
+    - name: ''
+    - host: 'localhost'
+    - connection_user: 'root'
+    - connection_pass: 'TOPSECRET'
+    - connection_charset: utf8
+
+mysql remove test database:
+  mysql_database.absent:
+    - name: test
+    - host: 'localhost'
+    - connection_user: 'root'
+    - connection_pass: 'TOPSECRET'
+    - connection_charset: utf8
+
+create api database:
+  mysql_database.present:
+    - name: api_production
+    - host: localhost
+    - connection_user: 'root'
+    - connection_pass: 'TOPSECRET'
+    - connection_charset: utf8
+
+create obs for api user@localhost:
+  mysql_user.present:
+    - name: obs
+    - host: localhost
+    - password: 'topsecretpasskey'
+
+create obs for api user@%:
+  mysql_user.present:
+    - name: obs
+    - host: \%
+    - password: 'topsecretpasskey'
+
+obs_grants to api obs@localhost:
+  mysql_grants.present:
+    - host: localhost
+    - database: api_production.\*
+    - grant: all privileges
+    - user: obs
+
+obs_grants to api obs@%:
+  mysql_grants.present:
+    - host: \%
+    - database: api_production.\*
+    - grant: all privileges
+    - user: obs
+
+create webui database:
+  mysql_database.present:
+    - name: webui_production
+    - host: localhost
+    - connection_user: 'root'
+    - connection_pass: 'TOPSECRET'
+    - connection_charset: utf8
+
+#Grant permissions to obs:
+#  mysql_query.run:
+#    - database: api_production
+#    - connection_user: root
+#    - connection_pass: TOPSECRET
+#    - output:   "/tmp/query_id.txt"
+#    - query: |
+#        GRANT all privileges ON api_production.* TO 'obs'@'%', 'obs'@'localhost';
+#        FLUSH PRIVILEGES;
+        
+grant permission:
+  cmd.script:
+    - name: grant_permissions.sh
+    - source: salt://llvm-obs/obs-scripts/grant_permissions.sh
+
+mysql_restart:
+  module.wait:
+    - name: service.restart
+    - m_name: mysql
+

--- a/mysql_init.sls
+++ b/mysql_init.sls
@@ -51,21 +51,12 @@ create obs for api user@%:
     - host: \%
     - password: {{salt['pillar.get']('obs-database:lookup:obs-api-database-password') }}
 
-create webui database:
-  mysql_database.present:
-    - name: {{salt['pillar.get']('obs-database:lookup:obs-webui-database') }}
-    - host: localhost
-    - connection_user: 'root'
-    - connection_pass: {{salt['pillar.get']('obs-database:lookup:root-password') }}
-    - connection_charset: utf8
-        
 grant permission:
   cmd.script:
     - name: grant_permissions.sh
-    - source: salt://obs_scripts/grant_permissions.sh
+    - source: salt://llvm-obs/obs-scripts/grant_permissions.sh
 
 mysql_restart:
   module.wait:
     - name: service.restart
     - m_name: mysql
-

--- a/mysql_init.sls
+++ b/mysql_init.sls
@@ -13,14 +13,14 @@ reload-mysql:
 root_user:
   mysql_user.present:
     - name: 'root'
-    - password: 'TOPSECRET'
+    - password: {{salt['pillar.get']('obs-database:lookup:root-password')}}
 
 mysql remove anonymous users:
   mysql_user.absent:
     - name: ''
     - host: 'localhost'
     - connection_user: 'root'
-    - connection_pass: 'TOPSECRET'
+    - connection_pass: {{salt['pillar.get']('obs-database:lookup:root-password') }}
     - connection_charset: utf8
 
 mysql remove test database:
@@ -28,65 +28,41 @@ mysql remove test database:
     - name: test
     - host: 'localhost'
     - connection_user: 'root'
-    - connection_pass: 'TOPSECRET'
+    - connection_pass: {{salt['pillar.get']('obs-database:lookup:root-password') }}
     - connection_charset: utf8
 
 create api database:
   mysql_database.present:
-    - name: api_production
+    - name: {{salt['pillar.get']('obs-database:lookup:obs-api-database') }}
     - host: localhost
     - connection_user: 'root'
-    - connection_pass: 'TOPSECRET'
+    - connection_pass: {{salt['pillar.get']('obs-database:lookup:root-password') }}
     - connection_charset: utf8
 
 create obs for api user@localhost:
   mysql_user.present:
-    - name: obs
+    - name: {{salt['pillar.get']('obs-database:lookup:obs-user') }}
     - host: localhost
-    - password: 'topsecretpasskey'
+    - password: {{salt['pillar.get']('obs-database:lookup:obs-api-database-password') }}
 
 create obs for api user@%:
   mysql_user.present:
-    - name: obs
+    - name: {{salt['pillar.get']('obs-database:lookup:obs-user') }}
     - host: \%
-    - password: 'topsecretpasskey'
-
-obs_grants to api obs@localhost:
-  mysql_grants.present:
-    - host: localhost
-    - database: api_production.\*
-    - grant: all privileges
-    - user: obs
-
-obs_grants to api obs@%:
-  mysql_grants.present:
-    - host: \%
-    - database: api_production.\*
-    - grant: all privileges
-    - user: obs
+    - password: {{salt['pillar.get']('obs-database:lookup:obs-api-database-password') }}
 
 create webui database:
   mysql_database.present:
-    - name: webui_production
+    - name: {{salt['pillar.get']('obs-database:lookup:obs-webui-database') }}
     - host: localhost
     - connection_user: 'root'
-    - connection_pass: 'TOPSECRET'
+    - connection_pass: {{salt['pillar.get']('obs-database:lookup:root-password') }}
     - connection_charset: utf8
-
-#Grant permissions to obs:
-#  mysql_query.run:
-#    - database: api_production
-#    - connection_user: root
-#    - connection_pass: TOPSECRET
-#    - output:   "/tmp/query_id.txt"
-#    - query: |
-#        GRANT all privileges ON api_production.* TO 'obs'@'%', 'obs'@'localhost';
-#        FLUSH PRIVILEGES;
         
 grant permission:
   cmd.script:
     - name: grant_permissions.sh
-    - source: salt://llvm-obs/obs-scripts/grant_permissions.sh
+    - source: salt://obs_scripts/grant_permissions.sh
 
 mysql_restart:
   module.wait:

--- a/obs-common.sls
+++ b/obs-common.sls
@@ -1,0 +1,4 @@
+obs common:
+  pkg.installed:
+    - pkgs:
+      - osc

--- a/obs-server.sls
+++ b/obs-server.sls
@@ -2,7 +2,8 @@ install obs server packages:
   pkg.installed:
     - pkgs:
       - obs-server
-      - obs-worker
+      - obs-utils
+      - osc
 
 obs-api:
   pkg:
@@ -11,32 +12,6 @@ obs-api:
      - name: /usr/share/obs/api/config/database.yml
      - source: salt://llvm-obs/obs-conf/obs-api_database.yml
      - template: jinja
-
-populate_database setup db:
-  cmd.run:
-     - name: "RAILS_ENV=\"production\" rake db:setup"
-     - cwd: /usr/share/obs/api/
-
-populate_database write configuration:
-  cmd.run:
-     - name: "RAILS_ENV=\"production\" rake writeconfiguration"
-     - cwd: /usr/share/obs/api/
-
-/usr/share/obs/api/log:
-  file.directory:
-    - user: www-data
-    - group: www-data
-    - recurse:
-      - user
-      - group
-
-/usr/share/obs/api/tmp:
-  file.directory:
-    - user: www-data
-    - group: www-data
-    - recurse:
-      - user
-      - group
 
 install apache:
   pkg.installed:
@@ -47,25 +22,11 @@ install apache:
       - libapache2-mod-xforward
       - memcached
 
-enable apache ssl module:
-  cmd.run:
-    - name: a2enmod ssl
-
 create self signed ssl for testing:
   cmd.script:
     - name: generate_ssl.sh
     - source: salt://llvm-obs/obs-scripts/generate_ssl.sh
 
-reload apache:
-  service.running:
-    - name: apache2
-    - enable: True
-    - reload: True
-
-obsapidelayed:
-  service.running:
-    - enable: True
-
-memcached:
-  service.running:
-    - enable: True
+rake task setup:
+  cmd.run:
+     - name: "bash /usr/share/obs/api/script/rake-tasks.sh setup"

--- a/obs-server.sls
+++ b/obs-server.sls
@@ -1,0 +1,65 @@
+install obs server packages:
+  pkg.installed:
+    - pkgs:
+      - obs-server
+      - obs-worker
+
+obs-api:
+  pkg:
+    - installed
+  file.managed:
+     - name: /usr/share/obs/api/config/database.yml
+     - source: salt://llvm-obs/obs-conf/obs-api_database.yml
+
+populate_database setup db:
+  cmd.run:
+     - name: "RAILS_ENV=\"production\" rake db:setup"
+     - cwd: /usr/share/obs/api/
+
+populate_database write configuration:
+  cmd.run:
+     - name: "RAILS_ENV=\"production\" rake writeconfiguration"
+     - cwd: /usr/share/obs/api/
+
+change permission for log:
+  cmd.run:
+     - name: "chown -R www-data /usr/share/obs/api/log"
+     - cwd: /usr/share/obs/api/
+
+change permission for tmp:
+  cmd.run:
+     - name: "chown -R www-data /usr/share/obs/api/tmp"
+     - cwd: /usr/share/obs/api
+
+install apache:
+  pkg.installed:
+    - pkgs:
+      - apache2
+      - apache2-utils
+      - libapache2-mod-passenger
+      - libapache2-mod-xforward
+      - memcached
+
+enable apache ssl module:
+  cmd.run:
+    - name: a2enmod ssl
+
+create self signed ssl for testing:
+  cmd.script:
+    - name: generate_ssl.sh
+    - source: salt://llvm-obs/obs-scripts/generate_ssl.sh
+
+reload apache:
+  service.running:
+    - name: apache2
+    - enable: True
+    - reload: True
+
+obsapidelayed:
+  service.running:
+    - enable: True
+
+memcached:
+  service.running:
+    - enable: True
+

--- a/obs-server.sls
+++ b/obs-server.sls
@@ -22,15 +22,21 @@ populate_database write configuration:
      - name: "RAILS_ENV=\"production\" rake writeconfiguration"
      - cwd: /usr/share/obs/api/
 
-change permission for log:
-  cmd.run:
-     - name: "chown -R www-data /usr/share/obs/api/log"
-     - cwd: /usr/share/obs/api/
+/usr/share/obs/api/log:
+  file.directory:
+    - user: www-data
+    - group: www-data
+    - recurse:
+      - user
+      - group
 
-change permission for tmp:
-  cmd.run:
-     - name: "chown -R www-data /usr/share/obs/api/tmp"
-     - cwd: /usr/share/obs/api
+/usr/share/obs/api/temp:
+  file.directory:
+    - user: www-data
+    - group: www-data
+    - recurse:
+      - user
+      - group
 
 install apache:
   pkg.installed:

--- a/obs-server.sls
+++ b/obs-server.sls
@@ -30,7 +30,7 @@ populate_database write configuration:
       - user
       - group
 
-/usr/share/obs/api/temp:
+/usr/share/obs/api/tmp:
   file.directory:
     - user: www-data
     - group: www-data

--- a/obs-server.sls
+++ b/obs-server.sls
@@ -9,7 +9,8 @@ obs-api:
     - installed
   file.managed:
      - name: /usr/share/obs/api/config/database.yml
-     - source: salt://llvm-obs/obs-conf/obs-api_database.yml
+     - source: salt://obs_conf/obs-api_database.yml
+     - template: jinja
 
 populate_database setup db:
   cmd.run:
@@ -47,7 +48,7 @@ enable apache ssl module:
 create self signed ssl for testing:
   cmd.script:
     - name: generate_ssl.sh
-    - source: salt://llvm-obs/obs-scripts/generate_ssl.sh
+    - source: salt://obs_scripts/generate_ssl.sh
 
 reload apache:
   service.running:
@@ -62,4 +63,3 @@ obsapidelayed:
 memcached:
   service.running:
     - enable: True
-

--- a/obs-server.sls
+++ b/obs-server.sls
@@ -9,7 +9,7 @@ obs-api:
     - installed
   file.managed:
      - name: /usr/share/obs/api/config/database.yml
-     - source: salt://obs_conf/obs-api_database.yml
+     - source: salt://llvm-obs/obs-conf/obs-api_database.yml
      - template: jinja
 
 populate_database setup db:
@@ -48,7 +48,7 @@ enable apache ssl module:
 create self signed ssl for testing:
   cmd.script:
     - name: generate_ssl.sh
-    - source: salt://obs_scripts/generate_ssl.sh
+    - source: salt://llvm-obs/obs-scripts/generate_ssl.sh
 
 reload apache:
   service.running:

--- a/obs-worker.sls
+++ b/obs-worker.sls
@@ -1,0 +1,33 @@
+install obs server packages:
+  pkg.installed:
+    - pkgs:
+      - obs-worker
+      - obs-utils
+
+enable obs workers:
+  file.replace:
+    - name: /etc/default/obsworker
+    - pattern: '^ENABLED=0'
+    - repl: 'ENABLED=1'
+    - count: 1
+
+set obs source server:
+  file.replace:
+    - name: /etc/default/obsworker
+    - pattern: '^OBS_SRC_SERVER="obs:5352"'
+    - repl: '{{salt['pillar.get']('obs-database:lookup:obs-server')}}:5352'
+    - count: 1
+
+set obs repo server:
+  file.replace:
+    - name: /etc/default/obsworker
+    - pattern: '^OBS_REPO_SERVER="obs:5252"'
+    - repl: '{{salt['pillar.get']('obs-database:lookup:obs-server')}}:5252'
+    - count: 1
+
+obsworker:
+  service.running:
+    - name: obsworker
+    - enable: True
+    - reload: True
+

--- a/top.sls
+++ b/top.sls
@@ -1,11 +1,14 @@
 base:
   '*':
     - apt-common
-#  'E@irill*':
-#    - match: compound
-#    - debile-servers
-#    - debile-servers-users
-  'E@blade*':
+#   - obs-common
+  'E@irill*':
     - match: compound
-    - llvm-slave
-    - apt-common-pinning
+    - debile-servers
+    - debile-servers-users
+#   - mysql_init
+#   - obs-server
+#  'E@blade*':
+#    - match: compound
+#    - llvm-slave
+#    - apt-common-pinning

--- a/top.sls
+++ b/top.sls
@@ -1,14 +1,14 @@
 base:
   '*':
     - apt-common
-#   - obs-common
   'E@irill*':
     - match: compound
     - debile-servers
     - debile-servers-users
-#   - mysql_init
-#   - obs-server
 #  'E@blade*':
 #    - match: compound
 #    - llvm-slave
 #    - apt-common-pinning
+#  'E@obs-server*':
+#    - obs-common
+#    - obs-server


### PR DESCRIPTION
Based on https://openbuildservice.org/help/manuals/obs-admin-guide/obs.cha.installation_and_configuration.html  .

Only setups the obs server on the master.
Will store username/passwords in pillar and use jinja templates for configuring files in later commit if needed.
Was not able to grant mysql user permissions with salt.states.mysql_grants or even with salts.states.mysql_query so used a bash script as a work around.
Will be coming with workers and obs-server worker configuration in future pr.

Could not set up vagrant even after series of errors and work around but have tested on my system link to salt log [here](https://paste.debian.net/1024891/).

Thanks