### PR TITLE
Added obs pillar data

### DIFF
--- a/obs-pillar/README
+++ b/obs-pillar/README
@@ -1,0 +1,1 @@
+The default pillar root is /srv/pillar and can be changed in salt master configuration.

--- a/obs-pillar/obs-database.sls
+++ b/obs-pillar/obs-database.sls
@@ -1,0 +1,9 @@
+obs-database:
+  lookup:
+    root-password: 'TOPSECRET'
+    obs-user: obs
+    obs-api-database: obs_api_production
+    obs-webui-database: obs_webui_production
+    obs-api-database-password: topsecretpasskey
+    obs-webui-database-password: topsecretpasskey
+    obs-server: localhost

--- a/obs-pillar/top.sls
+++ b/obs-pillar/top.sls
@@ -1,0 +1,3 @@
+base:
+  '*':
+    - obs-database

--- a/top.sls
+++ b/top.sls
@@ -7,6 +7,7 @@ base:
     - apt-common-pinning
   'E@obs-server* or E@irill8*':
     - obs-common
+    - mysql_init
     - obs-server
   'E@obs-worker* or E@korcula.*':
     - obs-common


### PR DESCRIPTION
Since the default pillar root is /srv/pillar. Either add this location to the pillar_root in /etc/salt/master or copy these(top.sls and obs-database.sls) to the default dir.

Thanks 